### PR TITLE
Add copy button above extracted text sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
         .results { margin-top: 32px; }
         .result-block { background: #f3f4f6; padding: 16px; border-radius: 12px; margin-bottom: 18px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.6); }
         .loading { color: #4f46e5; text-align: center; margin-top: 16px; font-weight: 500; }
-        .copy-controls { display: flex; justify-content: flex-start; gap: 12px; align-items: center; margin: 10px 0 6px; }
+        .extracted-header { display: flex; justify-content: space-between; align-items: center; margin: 10px 0 6px; gap: 12px; }
+        .extracted-header strong { font-size: 16px; color: #1f2937; }
+        .copy-controls { display: flex; justify-content: center; align-items: center; }
         .copy-button { background: linear-gradient(135deg, #6366f1, #8b5cf6); color: #fff; border: none; border-radius: 8px; padding: 8px 16px; cursor: pointer; font-size: 14px; font-weight: 600; transition: transform 0.2s ease, box-shadow 0.2s ease; }
         .copy-button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 6px 14px rgba(99, 102, 241, 0.3); }
         .copy-button:disabled { opacity: 0.6; cursor: not-allowed; box-shadow: none; }

--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ async function processFiles(files) {
         const copyButtonDefaultLabel = 'نسخ النص';
         const resultBlock = document.createElement('div');
         resultBlock.className = 'result-block';
-        resultBlock.innerHTML = `<strong>الصورة:</strong><br><img src="${imgURL}" style="max-width:100%;max-height:200px;"><br><strong>النص المستخرج:</strong><br><div class="copy-controls"><button type="button" class="copy-button" disabled>${copyButtonDefaultLabel}</button></div><pre style="background:#fff;border-radius:6px;padding:10px;white-space:pre-wrap;word-break:break-word;">جاري المعالجة...</pre>`;
+        resultBlock.innerHTML = `<strong>الصورة:</strong><br><img src="${imgURL}" style="max-width:100%;max-height:200px;"><br><div class="extracted-header"><strong>النص المستخرج:</strong><div class="copy-controls"><button type="button" class="copy-button" disabled>${copyButtonDefaultLabel}</button></div></div><pre style="background:#fff;border-radius:6px;padding:10px;white-space:pre-wrap;word-break:break-word;">جاري المعالجة...</pre>`;
         resultsDiv.appendChild(resultBlock);
         const copyButton = resultBlock.querySelector('.copy-button');
         copyButton.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- place the copy text button inside the extracted text header so it appears above every recognized block
- tweak layout styles to support the new header row and keep the copy button aligned with the label

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68cc552b42a8832f955840f41b24bf99