### PR TITLE
Add controls to adjust extracted text font size

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         .loading { color: #4f46e5; text-align: center; margin-top: 16px; font-weight: 500; }
         .extracted-header { display: flex; justify-content: space-between; align-items: center; margin: 10px 0 6px; gap: 12px; }
         .extracted-header strong { font-size: 16px; color: #1f2937; }
-        .copy-controls { display: flex; justify-content: flex-start; align-items: center; gap: 8px; }
+        .copy-controls { display: flex; justify-content: flex-start; align-items: center; gap: 8px; flex-wrap: wrap; }
         .action-button { color: #fff; border: none; border-radius: 8px; padding: 8px 16px; cursor: pointer; font-size: 14px; font-weight: 600; transition: transform 0.2s ease, box-shadow 0.2s ease; box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12); }
         .action-button:hover:not(:disabled) { transform: translateY(-1px); }
         .action-button:disabled { opacity: 0.6; cursor: not-allowed; box-shadow: none; }
@@ -29,6 +29,12 @@
         .copy-button:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(99, 102, 241, 0.3); }
         .edit-button { background: linear-gradient(135deg, #0ea5e9, #38bdf8); }
         .edit-button:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(14, 165, 233, 0.28); }
+        .font-controls { display: flex; align-items: center; gap: 6px; }
+        .font-button { min-width: 36px; padding: 8px 0; text-align: center; font-size: 18px; line-height: 1; }
+        .font-decrease { background: linear-gradient(135deg, #f97316, #fb923c); }
+        .font-decrease:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(249, 115, 22, 0.28); }
+        .font-increase { background: linear-gradient(135deg, #22c55e, #4ade80); }
+        .font-increase:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(34, 197, 94, 0.28); }
         .extracted-text { background: #fff; border-radius: 6px; padding: 10px; white-space: pre-wrap; word-break: break-word; transition: background 0.2s ease, box-shadow 0.2s ease; }
         .extracted-text.editing { outline: 2px solid #6366f1; background: #eef2ff; box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15); }
         @media (min-width: 640px) {

--- a/main.js
+++ b/main.js
@@ -31,11 +31,41 @@ async function processFiles(files) {
         const saveButtonLabel = 'حفظ التعديلات';
         const resultBlock = document.createElement('div');
         resultBlock.className = 'result-block';
-        resultBlock.innerHTML = `<strong>الصورة:</strong><br><img src="${imgURL}" style="max-width:100%;max-height:200px;"><br><div class="extracted-header"><strong>النص المستخرج:</strong><div class="copy-controls"><button type="button" class="action-button copy-button" disabled>${copyButtonDefaultLabel}</button><button type="button" class="action-button edit-button" disabled>${editButtonDefaultLabel}</button></div></div><pre class="extracted-text">جاري المعالجة...</pre>`;
+        resultBlock.innerHTML = `<strong>الصورة:</strong><br><img src="${imgURL}" style="max-width:100%;max-height:200px;"><br><div class="extracted-header"><strong>النص المستخرج:</strong><div class="copy-controls"><button type="button" class="action-button copy-button" disabled>${copyButtonDefaultLabel}</button><div class="font-controls"><button type="button" class="action-button font-button font-decrease" disabled>-</button><button type="button" class="action-button font-button font-increase" disabled>+</button></div><button type="button" class="action-button edit-button" disabled>${editButtonDefaultLabel}</button></div></div><pre class="extracted-text">جاري المعالجة...</pre>`;
         resultsDiv.appendChild(resultBlock);
         const copyButton = resultBlock.querySelector('.copy-button');
         const editButton = resultBlock.querySelector('.edit-button');
+        const decreaseFontButton = resultBlock.querySelector('.font-decrease');
+        const increaseFontButton = resultBlock.querySelector('.font-increase');
         const textElement = resultBlock.querySelector('.extracted-text');
+        const MIN_FONT_SIZE = 12;
+        const MAX_FONT_SIZE = 32;
+        let currentFontSize = parseFloat(window.getComputedStyle(textElement).fontSize) || 16;
+
+        const applyFontSize = () => {
+            textElement.style.fontSize = `${currentFontSize}px`;
+        };
+
+        const updateFontButtons = () => {
+            decreaseFontButton.disabled = currentFontSize <= MIN_FONT_SIZE;
+            increaseFontButton.disabled = currentFontSize >= MAX_FONT_SIZE;
+        };
+
+        applyFontSize();
+
+        decreaseFontButton.addEventListener('click', () => {
+            if (currentFontSize <= MIN_FONT_SIZE) return;
+            currentFontSize = Math.max(currentFontSize - 2, MIN_FONT_SIZE);
+            applyFontSize();
+            updateFontButtons();
+        });
+
+        increaseFontButton.addEventListener('click', () => {
+            if (currentFontSize >= MAX_FONT_SIZE) return;
+            currentFontSize = Math.min(currentFontSize + 2, MAX_FONT_SIZE);
+            applyFontSize();
+            updateFontButtons();
+        });
         copyButton.addEventListener('click', async () => {
             const textToCopy = textElement.textContent;
             const originalText = copyButtonDefaultLabel;
@@ -200,6 +230,9 @@ async function processFiles(files) {
             copyButton.textContent = copyButtonDefaultLabel;
             editButton.disabled = false;
             editButton.textContent = editButtonDefaultLabel;
+            decreaseFontButton.disabled = false;
+            increaseFontButton.disabled = false;
+            updateFontButtons();
         } catch (err) {
             textElement.textContent = 'حدث خطأ أثناء المعالجة.';
             isEditing = false;
@@ -210,6 +243,8 @@ async function processFiles(files) {
             copyButton.textContent = 'تعذّر المعالجة';
             editButton.disabled = true;
             editButton.textContent = editButtonDefaultLabel;
+            decreaseFontButton.disabled = true;
+            increaseFontButton.disabled = true;
         }
     }
     if (showProgress) {


### PR DESCRIPTION
## Summary
- add increase/decrease font size buttons next to the edit control for extracted text blocks
- style new controls to match the existing action buttons
- wire up JavaScript handlers to bound, apply, and disable the font size controls appropriately

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cc5fb55e58832f8438ab215fad850e