### PR TITLE
Add delete option with confirmation for OCR results

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
         .copy-button:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(99, 102, 241, 0.3); }
         .edit-button { background: linear-gradient(135deg, #0ea5e9, #38bdf8); }
         .edit-button:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(14, 165, 233, 0.28); }
+        .delete-button { background: linear-gradient(135deg, #ef4444, #f97316); }
+        .delete-button:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(239, 68, 68, 0.28); }
         .font-controls { display: flex; align-items: center; gap: 6px; }
         .font-button { min-width: 36px; padding: 8px 0; text-align: center; font-size: 18px; line-height: 1; }
         .font-decrease { background: linear-gradient(135deg, #f97316, #fb923c); }

--- a/main.js
+++ b/main.js
@@ -29,14 +29,16 @@ async function processFiles(files) {
         const copyButtonDefaultLabel = 'نسخ النص';
         const editButtonDefaultLabel = 'تحرير النص';
         const saveButtonLabel = 'حفظ التعديلات';
+        const deleteButtonLabel = 'حذف الصورة والنص';
         const resultBlock = document.createElement('div');
         resultBlock.className = 'result-block';
-        resultBlock.innerHTML = `<strong>الصورة:</strong><br><img src="${imgURL}" style="max-width:100%;max-height:200px;"><br><div class="extracted-header"><strong>النص المستخرج:</strong><div class="copy-controls"><button type="button" class="action-button copy-button" disabled>${copyButtonDefaultLabel}</button><div class="font-controls"><button type="button" class="action-button font-button font-decrease" disabled>-</button><button type="button" class="action-button font-button font-increase" disabled>+</button></div><button type="button" class="action-button edit-button" disabled>${editButtonDefaultLabel}</button></div></div><pre class="extracted-text">جاري المعالجة...</pre>`;
+        resultBlock.innerHTML = `<strong>الصورة:</strong><br><img src="${imgURL}" style="max-width:100%;max-height:200px;"><br><div class="extracted-header"><strong>النص المستخرج:</strong><div class="copy-controls"><button type="button" class="action-button copy-button" disabled>${copyButtonDefaultLabel}</button><div class="font-controls"><button type="button" class="action-button font-button font-decrease" disabled>-</button><button type="button" class="action-button font-button font-increase" disabled>+</button></div><button type="button" class="action-button edit-button" disabled>${editButtonDefaultLabel}</button><button type="button" class="action-button delete-button">${deleteButtonLabel}</button></div></div><pre class="extracted-text">جاري المعالجة...</pre>`;
         resultsDiv.appendChild(resultBlock);
         const copyButton = resultBlock.querySelector('.copy-button');
         const editButton = resultBlock.querySelector('.edit-button');
         const decreaseFontButton = resultBlock.querySelector('.font-decrease');
         const increaseFontButton = resultBlock.querySelector('.font-increase');
+        const deleteButton = resultBlock.querySelector('.delete-button');
         const textElement = resultBlock.querySelector('.extracted-text');
         const MIN_FONT_SIZE = 12;
         const MAX_FONT_SIZE = 32;
@@ -65,6 +67,15 @@ async function processFiles(files) {
             currentFontSize = Math.min(currentFontSize + 2, MAX_FONT_SIZE);
             applyFontSize();
             updateFontButtons();
+        });
+
+        deleteButton.addEventListener('click', () => {
+            const confirmation = confirm('هل أنت متأكد من حذف هذه الصورة والنص؟');
+            if (!confirmation) {
+                return;
+            }
+            URL.revokeObjectURL(imgURL);
+            resultBlock.remove();
         });
         copyButton.addEventListener('click', async () => {
             const textToCopy = textElement.textContent;


### PR DESCRIPTION
## Summary
- add a styled delete action button next to the OCR result controls
- prompt the user to confirm before deleting and remove the image/text block when confirmed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc61e75e14832fa47f35587ceb3ee3