### PR TITLE
Add scroll-to-top button for long pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,33 @@
         .font-increase:hover:not(:disabled) { box-shadow: 0 6px 14px rgba(34, 197, 94, 0.28); }
         .extracted-text { background: #fff; border-radius: 6px; padding: 10px; white-space: pre-wrap; word-break: break-word; transition: background 0.2s ease, box-shadow 0.2s ease; }
         .extracted-text.editing { outline: 2px solid #6366f1; background: #eef2ff; box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15); }
+        #scrollTopButton {
+            position: fixed;
+            bottom: 32px;
+            right: 32px;
+            width: 52px;
+            height: 52px;
+            border: none;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #6366f1, #8b5cf6);
+            color: #fff;
+            font-size: 24px;
+            cursor: pointer;
+            box-shadow: 0 12px 30px rgba(99, 102, 241, 0.25);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            transition: opacity 0.3s ease, visibility 0.3s ease, transform 0.3s ease;
+        }
+        #scrollTopButton:hover { transform: translateY(-4px); }
+        #scrollTopButton.visible {
+            opacity: 1;
+            visibility: visible;
+            pointer-events: auto;
+        }
         @media (min-width: 640px) {
             .options { flex-direction: row; }
             .option-card { flex: 1; }
@@ -81,6 +108,7 @@
         </div>
         <div id="results" class="results"></div>
     </div>
+    <button type="button" id="scrollTopButton" aria-label="العودة إلى أعلى الصفحة">⬆️</button>
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4/dist/tesseract.min.js"></script>
     <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -6,9 +6,24 @@ const GLOBAL_COPY_ERROR_LABEL = 'تعذّر النسخ';
 const GLOBAL_COPY_EMPTY_LABEL = 'لا يوجد نص لنسخه';
 
 const copyAllButton = document.getElementById('copyAllButton');
+const scrollTopButton = document.getElementById('scrollTopButton');
 let isGlobalCopyButtonLocked = false;
 if (copyAllButton) {
     copyAllButton.textContent = GLOBAL_COPY_DEFAULT_LABEL;
+}
+if (scrollTopButton) {
+    const toggleScrollButton = () => {
+        if (window.scrollY > 200) {
+            scrollTopButton.classList.add('visible');
+        } else {
+            scrollTopButton.classList.remove('visible');
+        }
+    };
+    window.addEventListener('scroll', toggleScrollButton);
+    window.addEventListener('load', toggleScrollButton);
+    scrollTopButton.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
 }
 
 async function copyToClipboard(text) {


### PR DESCRIPTION
## Summary
- add a floating scroll-to-top control that appears after the user scrolls down
- style the new control to match the existing gradient aesthetic and keep it hidden until needed
- wire up smooth scrolling behavior and visibility toggling in JavaScript

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc6ac20de4832fa94fbe7b7beffbf8